### PR TITLE
[feature] Create admin/cashier delete individual account view

### DIFF
--- a/UI/adminAccountInfo.html
+++ b/UI/adminAccountInfo.html
@@ -53,7 +53,8 @@
     <div class="shortcut-btns">
       <a href="#" onclick="handleStatusChange()" id="accnt-status-btn">Activate Account</a>
       <a href="#" onclick="handleAccountDebit()" id="accnt-status-btn">Debit Account</a>
-       <a href="#" onclick="handleAccountCredit()" id="accnt-status-btn">Credit Account</a>
+      <a href="#" onclick="handleAccountCredit()" id="accnt-status-btn">Credit Account</a>
+      <a href="#" onclick="handleAccountDelete()" id="accnt-status-btn" class="accnt-delete-btn">Delete Account</a>
     </div>
     <div class="accnt-info-disp">
       <div class="accnt-details">
@@ -135,6 +136,11 @@
               <input type="submit" name="confirmCredit" value="Confirm">
             </div>
           </form>
+          <div id="confirm-delete">
+            <p class="confirm-delete">Are you sure you want to delete this account?</p>
+            <button class="delete-accnt-btn">Confirm</button>
+            <button class="delete-accnt-btn">Cancel</button>
+          </div>
         </div>
       </div>
     </div>

--- a/UI/js/createAccount.js
+++ b/UI/js/createAccount.js
@@ -10,6 +10,8 @@ let text;
 const debitForm = document.getElementById("accnt-debit-form");
 const creditForm = document.getElementById("accnt-credit-form");
 
+const confirmDeleteMsg = document.getElementById("confirm-delete");
+
 // Change account status -deactivate or activte a bank account
 const badge = document.getElementById("accnt-badge");
 const accountStatusBtn = document.getElementById("accnt-status-btn");
@@ -42,6 +44,7 @@ const handleAccountSubmit = e => {
 // Function to debit account
 const handleAccountDebit = () => {
   // clear form area before displaying
+  confirmDeleteMsg.style.display = "none";
   creditForm.style.display = "none";
   debitForm.style.display = "block";
   modal.style.display = "block";
@@ -49,8 +52,16 @@ const handleAccountDebit = () => {
 
 // function to credit account
 const handleAccountCredit = () => {
+  confirmDeleteMsg.style.display = "none";
   debitForm.style.display = "none";
   creditForm.style.display = "block";
+  modal.style.display = "block";
+};
+
+const handleAccountDelete = () => {
+  debitForm.style.display = "none";
+  creditForm.style.display = "none";
+  confirmDeleteMsg.style.display = "block";
   modal.style.display = "block";
 };
 

--- a/UI/style.css
+++ b/UI/style.css
@@ -375,8 +375,21 @@ button.dropdown-trigger:focus {
   display: flex;
   flex-direction: row;
   flex-flow: row wrap;
-  max-width: 35%;
+  max-width: 45%;
   justify-content: space-between;
+}
+
+.delete-accnt-btn {
+  align-self: flex-end;
+  width: 150px;
+  height: 40px;
+  color: white;
+  cursor: pointer;
+  font-size: 15px;
+  font-family: Montserrat, sans-serif;
+  background: rgb(94, 53, 177);
+  border-radius: 25px;
+  box-shadow: 0 9px #999;
 }
 
 .shortcut-btns a{
@@ -386,6 +399,17 @@ button.dropdown-trigger:focus {
   padding: 7px 10px;
   border-radius: 25px;
   box-shadow: 0 9px #999;
+}
+
+.shortcut-btns a.accnt-delete-btn{
+  text-decoration: none;
+  background-color: red;
+}
+
+.shortcut-btns a.accnt-delete-btn:active{
+   background-color: rgb(255, 89, 29);
+  box-shadow: 0 5px #666;
+  transform: translateY(4px);
 }
 
 .shortcut-btns a:focus{
@@ -629,6 +653,10 @@ th.admin-accnts-th {
 }
 
 .accnt-credit-form {
+  display: none;
+}
+
+#confirm-delete {
   display: none;
 }
 


### PR DESCRIPTION
#### What does this PR do?
- Creates a modal view enabling an admin or cashier to delete an individual account

#### Description of Task to be completed?
 - [x] Admin/Cashier can delete a specific bank account

#### How should this be manually tested?
- After cloning to your repo, visit the `adminAccountInfo.html` page and click the Delete Account button

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- #164697564

#### Screenshots (if appropriate)
![Screenshot 2019-03-24 at 11 29 11 PM](https://user-images.githubusercontent.com/42325628/54886970-1b308d00-4e8e-11e9-98a8-aabe8165831f.png)

