### PR TITLE
[bugfix] Remove account activation button for non-admin user

### DIFF
--- a/UI/accountInfo.html
+++ b/UI/accountInfo.html
@@ -51,7 +51,6 @@
     </div>
     <div class="shortcut-btns">
       <a href="dashboard.html"><i class="fas fa-chevron-left"></i> Dashboard</a>
-      <a href="#" onclick="handleStatusChange()" id="accnt-status-btn">Deactivate Account</a>
     </div>
     <div class="accnt-info-disp">
       <div class="accnt-details">


### PR DESCRIPTION
#### What does this PR do?
- Removes the activation/deactivation feature for a non-admin user

#### Description of Task to be completed?
- [x] **Admin** or **staff** can activate or deactivate an account

#### How should this be manually tested?
- After cloning to your repo, visit the `accountInfo.html` page

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- #164851422

#### Screenshots (if appropriate)