### PR TITLE
#164932589 User (admin/staff) can activate or deactivate an account API endpoint

### DIFF
--- a/server/routes/AccountRoute.js
+++ b/server/routes/AccountRoute.js
@@ -1,14 +1,15 @@
 import { Router } from 'express';
 import AccountController from '../dummyControllers/AccountController';
 import Authorization from '../middleware/Authorization';
-import validateAccountCreation from '../validation/accountValidation';
+import { validateAccountCreation, validateEditAccount } from '../validation/accountValidation';
 
 const router = Router();
 
-const { fetchAllAccounts, createAccount } = AccountController;
+const { fetchAllAccounts, createAccount, editAccountStatus } = AccountController;
 const { checkToken } = Authorization;
 
 router.get('/', checkToken, fetchAllAccounts);
 router.post('/', checkToken, validateAccountCreation, createAccount);
+router.patch('/:accountNumber', checkToken, validateEditAccount, editAccountStatus);
 
 export default router;

--- a/server/validation/accountValidation.js
+++ b/server/validation/accountValidation.js
@@ -7,7 +7,7 @@ import { isEmpty } from './authValidation';
  * @param {Function} next Call back function
  * @route POST /api/v1/accounts
  * @returns {Object} status code and error message properties
- * @access public
+ * @access private
  */
 const validateAccountCreation = (req, res, next) => {
   const { type } = req.body;
@@ -29,4 +29,49 @@ const validateAccountCreation = (req, res, next) => {
   return next();
 };
 
-export default validateAccountCreation;
+/**
+ * @description Function to check that the parameters for editing an account status are properly formatted
+ * @param {Object} req The request object
+ * @param {Object} res The response object
+ * @param {Function} next Call back function
+ * @route PATCH /api/v1/accounts
+ * @returns {Object} status code and error message properties
+ * @access private
+ */
+const validateEditAccount = (req, res, next) => {
+  const { accountNumber } = req.params;
+  const { status } = req.body;
+  const isNum = /^\d+$/; // gotten from Scott Evernden on Stack Overflow
+
+  if (accountNumber.length !== 10) {
+    return res.status(400).json({
+      status: 400,
+      error: 'Account number must be 10 digits'
+    });
+  }
+
+  if (!isNum.test(accountNumber)) {
+    return res.status(400).json({
+      status: 400,
+      error: 'Account number can only contain digits'
+    });
+  }
+
+  if (isEmpty(status)) {
+    return res.status(400).json({
+      status: 400,
+      error: 'Please specify a status, either active or dormant'
+    });
+  }
+
+  if (status !== 'active' && status !== 'dormant') {
+    return res.status(400).json({
+      status: 400,
+      error: 'Status can only be active or dormant'
+    });
+  }
+
+  return next();
+};
+
+export { validateAccountCreation, validateEditAccount };

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -188,4 +188,170 @@ describe('Account Route', () => {
         done();
       });
   });
+
+  it("Should edit an account's status when a staff accesses the route", done => {
+    const newStatus = {
+      status: 'dormant'
+    };
+    const accountNumber = 5563847290;
+    chai
+      .request(app)
+      .patch(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', staffAuthToken)
+      .send(newStatus)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(200);
+        expect(res.body).to.have.nested.property('data.accountNumber');
+        expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
+  it("Should not edit an account's status if a non-staff user accesses the route", done => {
+    const newStatus = {
+      status: 'dormant'
+    };
+    const accountNumber = 5563847290;
+    chai
+      .request(app)
+      .patch(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', authToken)
+      .send(newStatus)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(401);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('You are not authorized to carry out that action');
+        expect(res.status).to.equal(401);
+        done();
+      });
+  });
+
+  it("Should not edit an account's status if the account number is more than 10 digits", done => {
+    const newStatus = {
+      status: 'dormant'
+    };
+    const accountNumber = 556384729990;
+    chai
+      .request(app)
+      .patch(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', staffAuthToken)
+      .send(newStatus)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Account number must be 10 digits');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
+  it("Should not edit an account's status if a status is not provided", done => {
+    const newStatus = { status: '' };
+    const accountNumber = 5563847290;
+    chai
+      .request(app)
+      .patch(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', staffAuthToken)
+      .send(newStatus)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Please specify a status, either active or dormant');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
+  it("Should not edit an account's status if an invalid status is provided", done => {
+    const newStatus = { status: 'lkdlskl' };
+    const accountNumber = 5563847290;
+    chai
+      .request(app)
+      .patch(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', staffAuthToken)
+      .send(newStatus)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Status can only be active or dormant');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
+  it("Should not deactivate an account that's already deactived", done => {
+    const newStatus = { status: 'dormant' };
+    const accountNumber = 5563847290;
+    chai
+      .request(app)
+      .patch(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', staffAuthToken)
+      .send(newStatus)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(409);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Account is already dormant');
+        expect(res.status).to.equal(409);
+        done();
+      });
+  });
+
+  it('Should return an error for an invalid account number', done => {
+    const newStatus = { status: 'dormant' };
+    const accountNumber = '553s847290';
+    chai
+      .request(app)
+      .patch(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', staffAuthToken)
+      .send(newStatus)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Account number can only contain digits');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
+  it('Should return an error message when an account that does not exist is requested', done => {
+    const newStatus = {
+      status: 'dormant'
+    };
+    const accountNumber = 5563847299;
+    chai
+      .request(app)
+      .patch(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', staffAuthToken)
+      .send(newStatus)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(404);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Account does not exist');
+        expect(res.status).to.equal(404);
+        done();
+      });
+  });
 });

--- a/test/miscellaneous.test.js
+++ b/test/miscellaneous.test.js
@@ -8,7 +8,7 @@ const { expect } = chai;
 /**
  * @description test for helper function
  */
-describe('Account model', () => {
+describe('Helper Function', () => {
   it('Should return true for an empty string', () => {
     const emptyString = isEmpty(' ');
     expect(emptyString).to.equal(true);


### PR DESCRIPTION
#### What does this PR do?
Creates an endpoint to activate an account or deactivate account depending on the current status of the account

#### Description of Task to be completed?
Have the following endpoint working:

`PATCH /api/v1/accounts/<account-number>`

#### How should this be manually tested?
After cloning the repo, cd into it and do the following:
```bash
# install dependencies
npm install

# run unit tests
npm test
```

Using Postman,
- Visit the sign in endpoint created in #29 to generate a token
- Set the token as the `Authorization` Header and visit the route stated above

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#164932589](https://www.pivotaltracker.com/story/show/164932589)

#### Screenshots (if appropriate)
N/a