### PR TITLE
#164932619 User (admin/staff) can delete an account API endpoint

### DIFF
--- a/server/dummyControllers/AccountController.js
+++ b/server/dummyControllers/AccountController.js
@@ -149,6 +149,41 @@ const AccountController = {
       status: 200,
       data
     });
+  },
+
+  /**
+   * @description Delete a single account
+   * @param {Object} req The request object
+   * @param {Object} res The response object
+   * @route Get /api/v1/accounts/:accountNumber
+   * @returns {Object} status code, data and message properties
+   * @access private Staff only
+   */
+  deleteAccount(req, res) {
+    const { accountNumber } = req.params;
+    if (req.decoded.type === 'staff') {
+      const accountToDelete = accounts.find(
+        account => account.accountNumber === parseInt(accountNumber, 10)
+      );
+      if (isEmpty(accountToDelete)) {
+        return res.status(404).json({
+          status: 404,
+          error: 'Account does not exist'
+        });
+      }
+      const index = accounts.indexOf(accountToDelete);
+      if (index > -1) {
+        accounts.splice(index, 1);
+        return res.status(200).json({
+          status: 200,
+          message: 'Account deleted successfully'
+        });
+      }
+    }
+    return res.status(401).json({
+      status: 401,
+      error: 'You are not authorized to delete an account'
+    });
   }
 };
 

--- a/server/routes/AccountRoute.js
+++ b/server/routes/AccountRoute.js
@@ -9,12 +9,19 @@ import {
 
 const router = Router();
 
-const { fetchAllAccounts, createAccount, editAccountStatus, getSingleAccount } = AccountController;
+const {
+  fetchAllAccounts,
+  createAccount,
+  editAccountStatus,
+  getSingleAccount,
+  deleteAccount
+} = AccountController;
 const { checkToken } = Authorization;
 
 router.get('/', checkToken, fetchAllAccounts);
 router.post('/', checkToken, validateAccountCreation, createAccount);
 router.patch('/:accountNumber', checkToken, validateEditAccount, editAccountStatus);
 router.get('/:accountNumber', checkToken, validateGetSingleAccount, getSingleAccount);
+router.delete('/:accountNumber', checkToken, validateGetSingleAccount, deleteAccount);
 
 export default router;

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -424,4 +424,58 @@ describe('Account Route', () => {
         done();
       });
   });
+
+  it('Should allow a staff user to do delete an account', done => {
+    const accountNumber = 5563847290;
+    chai
+      .request(app)
+      .delete(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', staffAuthToken)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(200);
+        expect(res.body)
+          .to.have.property('message')
+          .eql('Account deleted successfully');
+        expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
+  it('Should not allow a non-staff user to do delete an account', done => {
+    const accountNumber = 5563847290;
+    chai
+      .request(app)
+      .delete(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', authToken)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(401);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('You are not authorized to delete an account');
+        expect(res.status).to.equal(401);
+        done();
+      });
+  });
+
+  it('Should not delete a non-existing single account', done => {
+    const accountNumber = 5563847299;
+    chai
+      .request(app)
+      .delete(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', staffAuthToken)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(404);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Account does not exist');
+        expect(res.status).to.equal(404);
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
Creates an API endpoint for a user (staff) to delete an individual account

#### Description of Task to be completed?
Have the following endpoint working:

`DELETE /api/v1/accounts/<account-number>`

#### How should this be manually tested?
After cloning the repo, cd into it and do the following:

```bash
# install dependencies
npm install

# run unit tests
npm test
```

Using Postman, do the following:
- Visit the sign in route from #29 and generate a token
- Add the token to the Header as `Authorization` and visit the route listed above

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#164932619](https://www.pivotaltracker.com/story/show/164932619)

#### Screenshots (if appropriate)
N/a