### PR TITLE
#165389702 Change incorrect password error message to email or password incorrect

### DIFF
--- a/server/dummyControllers/AuthController.js
+++ b/server/dummyControllers/AuthController.js
@@ -70,41 +70,35 @@ export default class AuthController {
   static signIn(req, res) {
     const { email, password } = req.body;
     for (let i = 0; i < users.length; i += 1) {
-      if (email === users[i].email) {
-        if (password === users[i].password) {
-          const userInfo = users[i];
-          const payload = {
-            id: userInfo.id,
-            email: userInfo.email,
-            type: userInfo.type,
-            firstName: userInfo.firstName,
-            lastName: userInfo.lastName,
-            isAdmin: userInfo.isAdmin
-          };
-          const token = jwt.sign(payload, process.env.SECRET_KEY, { expiresIn: '1hr' });
-          const data = {
-            token,
-            id: userInfo.id,
-            firstName: userInfo.firstName,
-            lastName: userInfo.lastName,
-            email: userInfo.email,
-            type: userInfo.type
-          };
-          return res.status(200).json({
-            status: 200,
-            data,
-            message: 'Login successful'
-          });
-        }
-        return res.status(403).json({
-          status: 403,
-          error: 'Password Incorrect'
+      if (email === users[i].email && password === users[i].password) {
+        const userInfo = users[i];
+        const payload = {
+          id: userInfo.id,
+          email: userInfo.email,
+          type: userInfo.type,
+          firstName: userInfo.firstName,
+          lastName: userInfo.lastName,
+          isAdmin: userInfo.isAdmin
+        };
+        const token = jwt.sign(payload, process.env.SECRET_KEY, { expiresIn: '1hr' });
+        const data = {
+          token,
+          id: userInfo.id,
+          firstName: userInfo.firstName,
+          lastName: userInfo.lastName,
+          email: userInfo.email,
+          type: userInfo.type
+        };
+        return res.status(200).json({
+          status: 200,
+          data,
+          message: 'Login successful'
         });
       }
     }
     return res.status(404).json({
       status: 404,
-      error: 'User not found'
+      error: 'Email or password is incorrect'
     });
   }
 }

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -325,27 +325,6 @@ describe('User Route', () => {
       });
   });
 
-  it('Should not log in a non-existent user', done => {
-    const user = {
-      email: 'harrypotter@hogwarts.com',
-      password: 'lumosMaxima'
-    };
-    chai
-      .request(app)
-      .post(`${API_PREFIX}/signin`)
-      .send(user)
-      .end((err, res) => {
-        expect(res.body)
-          .to.have.property('status')
-          .eql(404);
-        expect(res.body)
-          .to.have.property('error')
-          .eql('User not found');
-        expect(res.status).to.equal(404);
-        done();
-      });
-  });
-
   it('Should not log in a user with an empty email field', done => {
     const user = {
       email: '',
@@ -409,7 +388,7 @@ describe('User Route', () => {
       });
   });
 
-  it('Should not log in a user with a wrong password', done => {
+  it('Should not log in a user with wrong details', done => {
     const user = {
       email: 'obiwan@therebellion.com',
       password: 'pass'
@@ -421,11 +400,11 @@ describe('User Route', () => {
       .end((err, res) => {
         expect(res.body)
           .to.have.property('status')
-          .eql(403);
+          .eql(404);
         expect(res.body)
           .to.have.property('error')
-          .eql('Password Incorrect');
-        expect(res.status).to.equal(403);
+          .eql('Email or password is incorrect');
+        expect(res.status).to.equal(404);
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
Implements LFA feedback to fix a security issue where the server response for wrong user credentials is `password incorrect` and changes it to `Email or password is incorrect`

#### Description of Task to be completed?
Change `incorrect password` error message to `Email or password is incorrect`

#### How should this be manually tested?
After cloning the repo, `cd` into it and install the dependencies by running `npm install`
Unit tests are also available and can be run by entering `npm test` at the command line 

Using Postman:
- Visit the route `localhost:5000/api/v1/signin` and in the form field for email, enter `obiwan@therebellion.com`
This should cause the server to respond with the error message stated above

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#165389702](https://www.pivotaltracker.com/story/show/165389702)

#### Screenshots (if appropriate)
N/a