### PR TITLE
#165392775 Remove confirm password field from user registration fields on API route

### DIFF
--- a/server/dummyControllers/AuthController.js
+++ b/server/dummyControllers/AuthController.js
@@ -17,46 +17,43 @@ export default class AuthController {
    * @access public
    */
   static signUp(req, res) {
-    // eslint-disable-next-line no-unused-vars
-    const { firstName, lastName, email, password, password2 } = req.body;
+    const { firstName, lastName, email, password } = req.body;
     const existingUser = users.some(user => user.email === email);
-    if (!existingUser) {
-      const newUser = new User();
-      const usersLength = users.length;
-      const lastID = users[usersLength - 1].id;
-      const newID = lastID + 1;
-      newUser.id = newID;
-      newUser.firstName = firstName.trim();
-      newUser.lastName = lastName.trim();
-      newUser.email = email.trim();
-      newUser.password = password.trim();
-      newUser.type = 'client';
-      newUser.createdAt = new Date();
-
-      users.push(newUser);
-      const payload = { id: newUser.id, email: newUser.email };
-      const token = jwt.sign(payload, process.env.SECRET_KEY, { expiresIn: '1hr' });
-      const data = {
-        token,
-        id: newUser.id,
-        firstName: newUser.firstName,
-        lastName: newUser.lastName,
-        email: newUser.email,
-        type: newUser.type,
-        createdAt: newUser.createdAt
-      };
-      return res.status(201).json({
-        status: 201,
-        data,
-        message: 'User registered successfully'
+    if (existingUser) {
+      return res.status(409).json({
+        status: 409,
+        error: 'User already exists'
       });
     }
-    res.status(409).json({
-      status: 409,
-      error: 'User already exists'
-    });
+    const newUser = new User();
+    const usersLength = users.length;
+    const lastID = users[usersLength - 1].id;
+    const newID = lastID + 1;
+    newUser.id = newID;
+    newUser.firstName = firstName.trim();
+    newUser.lastName = lastName.trim();
+    newUser.email = email.trim();
+    newUser.password = password.trim();
+    newUser.type = 'client';
+    newUser.createdAt = new Date();
 
-    return true;
+    users.push(newUser);
+    const payload = { id: newUser.id, email: newUser.email };
+    const token = jwt.sign(payload, process.env.SECRET_KEY, { expiresIn: '1hr' });
+    const data = {
+      token,
+      id: newUser.id,
+      firstName: newUser.firstName,
+      lastName: newUser.lastName,
+      email: newUser.email,
+      type: newUser.type,
+      createdAt: newUser.createdAt
+    };
+    return res.status(201).json({
+      status: 201,
+      data,
+      message: 'User registered successfully'
+    });
   }
 
   /**

--- a/server/validation/authValidation.js
+++ b/server/validation/authValidation.js
@@ -24,16 +24,10 @@ export default class AuthValidation {
    * @access public
    */
   static validateUserSignup(req, res, next) {
-    const { firstName, lastName, email, password, password2 } = req.body;
+    const { firstName, lastName, email, password } = req.body;
     // Regular expression to check for valid email address - emailregex.com
     const validEmail = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-    if (
-      isEmpty(firstName) &&
-      isEmpty(lastName) &&
-      isEmpty(email) &&
-      isEmpty(password) &&
-      isEmpty(password2)
-    ) {
+    if (isEmpty(firstName) && isEmpty(lastName) && isEmpty(email) && isEmpty(password)) {
       return res.status(400).json({
         status: 400,
         error: 'All fields are required'
@@ -72,20 +66,6 @@ export default class AuthValidation {
       return res.status(400).json({
         status: 400,
         error: 'Password is required'
-      });
-    }
-
-    if (isEmpty(password2)) {
-      return res.status(400).json({
-        status: 400,
-        error: 'Confirm password field is required'
-      });
-    }
-
-    if (password !== password2) {
-      return res.status(400).json({
-        status: 400,
-        error: 'Passwords must match'
       });
     }
 

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -18,8 +18,7 @@ describe('User Route', () => {
       firstName: 'Darth',
       lastName: 'Vader',
       email: 'darth@theempire.com',
-      password: 'empireRulez',
-      password2: 'empireRulez'
+      password: 'empireRulez'
     };
     chai
       .request(app)
@@ -43,8 +42,7 @@ describe('User Route', () => {
       firstName: 'Severus',
       lastName: 'Snape',
       email: 'snape@hogwarts.com',
-      password: 'mischiefmanaged',
-      password2: 'mischiefmanaged'
+      password: 'mischiefmanaged'
     };
     chai
       .request(app)
@@ -68,8 +66,7 @@ describe('User Route', () => {
       firstName: '',
       lastName: 'MarVell',
       email: 'captain@marvel.com',
-      password: 'quantum',
-      password2: 'quantum'
+      password: 'quantum'
     };
     chai
       .request(app)
@@ -92,8 +89,7 @@ describe('User Route', () => {
       firstName: 'Carol',
       lastName: '',
       email: 'carol@marvell.com',
-      password: 'quantom1',
-      password2: 'quantom2'
+      password: 'quantom1'
     };
     chai
       .request(app)
@@ -116,8 +112,7 @@ describe('User Route', () => {
       firstName: 'Bon',
       lastName: 'Iver',
       email: '',
-      password: '715creeks',
-      password2: '715creeks'
+      password: '715creeks'
     };
     chai
       .request(app)
@@ -140,8 +135,7 @@ describe('User Route', () => {
       firstName: 'Bon',
       lastName: 'Iver',
       email: 'boniver@creeks.com',
-      password: '',
-      password2: '715Creeks'
+      password: ''
     };
     chai
       .request(app)
@@ -159,37 +153,12 @@ describe('User Route', () => {
       });
   });
 
-  it('Should not register a user without matching passwords', done => {
-    const newUser = {
-      firstName: 'Bon',
-      lastName: 'Iver',
-      email: 'boniver@creeks.com',
-      password: '715Creeks',
-      password2: 'creeks'
-    };
-    chai
-      .request(app)
-      .post(`${API_PREFIX}/signup`)
-      .send(newUser)
-      .end((err, res) => {
-        expect(res.body)
-          .to.have.property('status')
-          .eql(400);
-        expect(res.body)
-          .to.have.property('error')
-          .eql('Passwords must match');
-        expect(res.status).to.equal(400);
-        done();
-      });
-  });
-
   it('Should not register a user with an existing email address', done => {
     const newUser = {
       firstName: 'Thor',
       lastName: 'Odinson',
       email: 'thor@avengers.com',
-      password: 'password123',
-      password2: 'password123'
+      password: 'password123'
     };
     chai
       .request(app)
@@ -212,8 +181,7 @@ describe('User Route', () => {
       firstName: '',
       lastName: '',
       email: '',
-      password: '',
-      password2: ''
+      password: ''
     };
     chai
       .request(app)
@@ -236,8 +204,7 @@ describe('User Route', () => {
       firstName: 'Marshall',
       lastName: 'Matters',
       email: 'eminem',
-      password: 'superman1',
-      password2: 'superman1'
+      password: 'superman1'
     };
     chai
       .request(app)
@@ -260,8 +227,7 @@ describe('User Route', () => {
       firstName: 'Marshall',
       lastName: 'Matters',
       email: 'eminem@eminem.com',
-      password: 'supes',
-      password2: 'supes'
+      password: 'supes'
     };
     chai
       .request(app)
@@ -274,30 +240,6 @@ describe('User Route', () => {
         expect(res.body)
           .to.have.property('error')
           .eql('Password must be at least 6 characters long');
-        expect(res.status).to.equal(400);
-        done();
-      });
-  });
-
-  it('Should not register a new user with if confirm password field is missing', done => {
-    const newUser = {
-      firstName: 'Marshall',
-      lastName: 'Matters',
-      email: 'eminem@eminem.com',
-      password: 'superman123',
-      password2: ''
-    };
-    chai
-      .request(app)
-      .post(`${API_PREFIX}/signup`)
-      .send(newUser)
-      .end((err, res) => {
-        expect(res.body)
-          .to.have.property('status')
-          .eql(400);
-        expect(res.body)
-          .to.have.property('error')
-          .eql('Confirm password field is required');
         expect(res.status).to.equal(400);
         done();
       });


### PR DESCRIPTION
#### What does this PR do?
Implements LFA feedback to remove the unnecessary password2 field from user registration fields

#### Description of Task to be completed?
Remove redundant field; `password2` from user registration fields API route

#### How should this be manually tested?
After cloning the repo, `cd` into it and install the required dependencies by running `npm install`
Run unit tests by typing the command `npm test` at the command line

Using Postman:
- Access the route `localhost:5000/api/v1/auth/signup` to register a new user, the required fields now would just be `firstName`, `lastName`, `email`, & `password`

#### Any background context you want to provide?
Confirmation of password should be handled on the frontend so implementing it on the server would be somewhat redundant

#### What are the relevant pivotal tracker stories?
[#165392775](https://www.pivotaltracker.com/story/show/165392775)

#### Screenshots (if appropriate)
N/a