### PR TITLE
#165440391 Add 'draft' to status options for an account

### DIFF
--- a/server/db/seeder.js
+++ b/server/db/seeder.js
@@ -77,6 +77,8 @@ const createTable = async () => {
   VALUES(5563847290, 2, 'thor@avengers.com', 'current', 'active', 349876358.08);
   INSERT INTO accounts (accountNumber, owner, ownerEmail, type, status, balance)
   VALUES(8897654324, 3, 'olegunnar@manutd.com', 'savings', 'dormant', 7665435.97);
+  INSERT INTO accounts (accountNumber, owner, ownerEmail, type, status, balance)
+  VALUES(8894354324, 3, 'olegunnar@manutd.com', 'current', 'draft', 43435.97);
   INSERT INTO transactions (type, accountNumber, owner, cashier, amount, oldBalance, newBalance)
   VALUES('credit', 8897654324, 3, 4, 400500.0, 7264935.97, 7665435.97);
   INSERT INTO transactions (type, accountNumber, owner, cashier, amount, oldBalance, newBalance)

--- a/server/validation/accountValidation.js
+++ b/server/validation/accountValidation.js
@@ -65,7 +65,7 @@ export default class AccountValidation {
       });
     }
 
-    if (status !== 'active' && status !== 'dormant') {
+    if (status !== 'active' && status !== 'dormant' && status !== 'draft') {
       return res.status(400).json({
         status: 400,
         error: 'Status can only be active or dormant'

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -210,6 +210,26 @@ describe('Account Route', () => {
       });
   });
 
+  it("Should edit an account's status to draft when a staff accesses the route", done => {
+    const newStatus = {
+      status: 'draft'
+    };
+    const accountNumber = 8897654324;
+    chai
+      .request(app)
+      .patch(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', staffAuthToken)
+      .send(newStatus)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(200);
+        expect(res.body).to.have.nested.property('data[0].accountNumber');
+        expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
   it("Should not edit an account's status if a non-staff user accesses the route", done => {
     const newStatus = {
       status: 'dormant'


### PR DESCRIPTION
#### What does this PR do?
Add's an option for the status of an account to be `draft`

#### Description of Task to be completed?
Add `draft` to status options for an account

#### How should this be manually tested?
This can be tested by following the instructions and visiting the route updated in PR #54 

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#165440391](https://www.pivotaltracker.com/story/show/165440391)

#### Screenshots (if appropriate)



