### PR TITLE
#165445416 Implement LFA feedback on checking for extra keys in request body

### DIFF
--- a/server/validation/accountValidation.js
+++ b/server/validation/accountValidation.js
@@ -11,6 +11,12 @@ export default class AccountValidation {
    * @access private
    */
   static validateAccountCreation(req, res, next) {
+    if (Object.keys(req.body).length > 1) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Only the account type is required'
+      });
+    }
     const { type } = req.body;
 
     if (isEmpty(type)) {
@@ -40,6 +46,12 @@ export default class AccountValidation {
    * @access private
    */
   static validateEditAccount(req, res, next) {
+    if (Object.keys(req.body).length > 1) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Only the status field is required'
+      });
+    }
     const { accountNumber } = req.params;
     const { status } = req.body;
     const isNum = /^\d+$/; // gotten from Scott Evernden on Stack Overflow

--- a/server/validation/authValidation.js
+++ b/server/validation/authValidation.js
@@ -24,6 +24,12 @@ export default class AuthValidation {
    * @access public
    */
   static validateUserSignup(req, res, next) {
+    if (Object.keys(req.body).length > 4) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Only first name, last name, email and password fields are required'
+      });
+    }
     const { firstName, lastName, email, password } = req.body;
     // Regular expression to check for valid email address - emailregex.com
     const validEmail = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -89,6 +95,12 @@ export default class AuthValidation {
    * @access public
    */
   static validateUserLogIn(req, res, next) {
+    if (Object.keys(req.body).length > 2) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Only email and password fields are required'
+      });
+    }
     const { email, password } = req.body;
 
     if (isEmpty(email) && isEmpty(password)) {

--- a/server/validation/transactionValidation.js
+++ b/server/validation/transactionValidation.js
@@ -12,6 +12,12 @@ export default class TransactionValidation {
    * @access private
    */
   static validateCreditTransaction(req, res, next) {
+    if (Object.keys(req.body).length > 1) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Only the credit amount is required'
+      });
+    }
     const { creditAmount } = req.body;
 
     if (isEmpty(creditAmount)) {
@@ -49,6 +55,12 @@ export default class TransactionValidation {
    * @access private
    */
   static validateDebitTransaction(req, res, next) {
+    if (Object.keys(req.body).length > 1) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Only the debit amount is required'
+      });
+    }
     const { debitAmount } = req.body;
 
     if (isEmpty(debitAmount)) {

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -69,6 +69,28 @@ describe('Account Route', () => {
       });
   });
 
+  it('Should not create an account for a new user when an extra key exists in the request', done => {
+    const newAccount = {
+      type: 'savings',
+      something: 'irrelivant'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/accounts`)
+      .set('Authorization', authToken)
+      .send(newAccount)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Only the account type is required');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
   it('Should not create an account for a staff', done => {
     const newAccount = {
       type: 'current'
@@ -226,6 +248,29 @@ describe('Account Route', () => {
           .eql(200);
         expect(res.body).to.have.nested.property('data[0].accountNumber');
         expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
+  it("Should not edit an account's status when an extra key exists in the request", done => {
+    const newStatus = {
+      status: 'draft',
+      something: 'irrelivant'
+    };
+    const accountNumber = 8897654324;
+    chai
+      .request(app)
+      .patch(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', staffAuthToken)
+      .send(newStatus)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Only the status field is required');
+        expect(res.status).to.equal(400);
         done();
       });
   });

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -85,6 +85,30 @@ describe('User Route', () => {
       });
   });
 
+  it('Should not register if an extra key exists in the request body', done => {
+    const newUser = {
+      firstName: '',
+      lastName: 'MarVell',
+      email: 'captain@marvel.com',
+      password: 'quantum',
+      something: 'notnecessary'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/signup`)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Only first name, last name, email and password fields are required');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
   it('Should not register a user with an empty last name field', done => {
     const newUser = {
       firstName: 'Carol',
@@ -263,6 +287,28 @@ describe('User Route', () => {
           .to.have.property('message')
           .eql('Login successful');
         expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
+  it('Should not log in a user when an extra key exists in the request body', done => {
+    const user = {
+      email: 'darth@theempire.com',
+      password: 'password123',
+      something: 'notuseful'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/signin`)
+      .send(user)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Only email and password fields are required');
+        expect(res.status).to.equal(400);
         done();
       });
   });

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -95,6 +95,29 @@ describe('Transaction Route', () => {
       });
   });
 
+  it('Should not credit an account if the request contains an extra value', done => {
+    const creditTransaction = {
+      creditAmount: 500900.05,
+      something: 'else'
+    };
+    const accountNumber = 8897654324;
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/transactions/${accountNumber}/credit`)
+      .set('Authorization', authToken)
+      .send(creditTransaction)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Only the credit amount is required');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
   it('Should not credit an account that does not exist', done => {
     const creditTransaction = {
       creditAmount: 500900.05
@@ -227,6 +250,29 @@ describe('Transaction Route', () => {
           .to.have.property('error')
           .eql('You are not authorized to carry out that action');
         expect(res.status).to.equal(401);
+        done();
+      });
+  });
+
+  it('Should not debit an account if the request contains an extra value', done => {
+    const debitTransaction = {
+      debitAmount: 500900.05,
+      something: 'else'
+    };
+    const accountNumber = 8897654324;
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/transactions/${accountNumber}/debit`)
+      .set('Authorization', authToken)
+      .send(debitTransaction)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Only the debit amount is required');
+        expect(res.status).to.equal(400);
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
Implements LFA feedback on checking for extra keys on incoming requests

#### Description of Task to be completed?
Check for extra parameters in the body of all requests

#### How should this be manually tested?
After cloning this repo, `cd` into it and do the following: 

```bash
# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run dev
```
Using Postman, visit any of the following routes; 
`POST /api/v1/auth/siginin`
`POST /api/v1/auth/signup`
`POST /api/v1/accounts`
and make a request with an extra value in the request body

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#165445416](https://www.pivotaltracker.com/story/show/165445416)

#### Screenshots (if appropriate)
N/a