### PR TITLE
#165199936 Admin can change a client to staff user account via the create staff API endpoint

### DIFF
--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -41,4 +41,45 @@ export default class UserController {
       data: userAccounts
     });
   }
+
+  /**
+   * @description Get a all accounts owned by a user
+   * @param {Object} req The request object
+   * @param {Object} res The response object
+   * @route Get /api/v1/users/:user-email-address/accounts
+   * @returns {Object} status code, data and message properties
+   * @access private Staff and Client
+   */
+  static async adminAddStaff(req, res) {
+    if (req.decoded.isAdmin) {
+      const { userEmail } = req.body;
+      const findUser = await users.select(['*'], [`email='${userEmail}'`]);
+
+      if (isEmpty(findUser)) {
+        return res.status(404).json({
+          status: 404,
+          error: 'User not found'
+        });
+      }
+      const { type, isAdmin } = findUser[0];
+      if (type === 'staff' || isAdmin) {
+        return res.status(400).json({
+          status: 400,
+          error: 'User is already a staff'
+        });
+      }
+
+      const updatedUser = await users.update([`type='staff'`], [`email='${userEmail}'`]);
+      return res.status(200).json({
+        status: 200,
+        data: updatedUser,
+        message: 'User is now a staff'
+      });
+    }
+
+    return res.status(403).json({
+      status: 403,
+      error: 'You are not allowed to carry out that action'
+    });
+  }
 }

--- a/server/db/seeder.js
+++ b/server/db/seeder.js
@@ -72,7 +72,7 @@ const createTable = async () => {
   INSERT INTO users (email, firstName, lastName, password, address, avatar, phoneNumber, type, isAdmin)
   VALUES('olegunnar@manutd.com', 'Ole', 'Solksjaer', '${userPass}', 'Old Trafford, Manchester', '/uploads/avatar/ole.jpg', 08739084, 'client', false);
   INSERT INTO users (email, firstName, lastName, password, address, avatar, phoneNumber, type, isAdmin)
-  VALUES('kyloren@vader.com', 'Kylo', 'Ren', '${adminPass}', 'Tatooine, Planet C53', '/uploads/avatar/kylo.jpg', 08939084, 'staff', true);
+  VALUES('kyloren@vader.com', 'Kylo', 'Ren', '${adminPass}', 'Tatooine, Planet C53', '/uploads/avatar/kylo.jpg', 08939084, 'staff', false);
   INSERT INTO accounts (accountNumber, owner, ownerEmail, type, status, balance)
   VALUES(5563847290, 2, 'thor@avengers.com', 'current', 'active', 349876358.08);
   INSERT INTO accounts (accountNumber, owner, ownerEmail, type, status, balance)
@@ -80,7 +80,7 @@ const createTable = async () => {
   INSERT INTO accounts (accountNumber, owner, ownerEmail, type, status, balance)
   VALUES(8894354324, 3, 'olegunnar@manutd.com', 'current', 'draft', 43435.97);
   INSERT INTO accounts (accountNumber, owner, ownerEmail, type, status, balance)
-  VALUES(4294354324, 3, 'thor@avengers.com', 'current', 'draft', 43435.97);
+  VALUES(4294354324, 2, 'thor@avengers.com', 'current', 'draft', 43435.97);
   INSERT INTO transactions (type, accountNumber, owner, cashier, amount, oldBalance, newBalance)
   VALUES('credit', 8897654324, 3, 4, 400500.0, 7264935.97, 7665435.97);
   INSERT INTO transactions (type, accountNumber, owner, cashier, amount, oldBalance, newBalance)

--- a/server/routes/UserRoute.js
+++ b/server/routes/UserRoute.js
@@ -6,9 +6,9 @@ import asyncErrorHandler from '../middleware/asyncErrorHandler';
 
 const router = Router();
 
-const { fetchAllAccountsByUser } = UserController;
+const { fetchAllAccountsByUser, adminAddStaff } = UserController;
 const { checkToken } = Authorization;
-const { validateFetchUsersAccounts } = UserValidation;
+const { validateFetchUsersAccounts, validateAddStaff } = UserValidation;
 
 router.get(
   '/:userEmail/accounts',
@@ -16,5 +16,7 @@ router.get(
   validateFetchUsersAccounts,
   asyncErrorHandler(fetchAllAccountsByUser)
 );
+
+router.patch('/', checkToken, validateAddStaff, asyncErrorHandler(adminAddStaff));
 
 export default router;

--- a/server/validation/userValidation.js
+++ b/server/validation/userValidation.js
@@ -1,4 +1,7 @@
 /* eslint-disable no-useless-escape */
+import { isEmpty } from './authValidation';
+// Regular expression to check for valid email address - emailregex.com
+const validEmail = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 export default class UserValidation {
   /**
    * @description Function to check params when fetching a users accounts
@@ -11,14 +14,38 @@ export default class UserValidation {
    */
   static validateFetchUsersAccounts(req, res, next) {
     const { userEmail } = req.params;
-    // Regular expression to check for valid email address - emailregex.com
-    const validEmail = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     if (!validEmail.test(userEmail)) {
       return res.status(400).json({
         status: 400,
         error: 'Please provide a valid email address'
       });
     }
+    return next();
+  }
+
+  static validateAddStaff(req, res, next) {
+    const { userEmail } = req.body;
+    if (Object.keys(req.body).length > 1) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Only the user email is required'
+      });
+    }
+
+    if (isEmpty(userEmail)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'User email is required'
+      });
+    }
+
+    if (!validEmail.test(userEmail)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Please provide a valid email address'
+      });
+    }
+
     return next();
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Creates an API endpoint for Admins to add staff users

#### Description of Task to be completed?
Admin should be able to upgrade a client's account to a staff account on the following endpoint:
`PATCH -> /api/v1/user`

#### How should this be manually tested?
After cloning the repo, `cd` into it and do the following:
```bash
# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run dev
```
Using Postman, you can visit the sign in route from #53 and sign in with the details from the test accounts and visit the route stated above, and add the `userEmail` to the request body to change an existing user to a staff

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#165199936](https://www.pivotaltracker.com/story/show/165199936)

#### Screenshots (if appropriate)
N/a