### PR TITLE
#165627358 Fix issue where a former client upgraded to staff can perform transactions on their account

### DIFF
--- a/server/controllers/TransactionController.js
+++ b/server/controllers/TransactionController.js
@@ -50,6 +50,13 @@ export default class TransactionController {
     }
 
     const { balance, owner } = accountToCredit[0];
+
+    if (req.decoded.id === owner) {
+      return res.status(401).json({
+        status: 401,
+        error: 'You are not allowed to carry out that action'
+      });
+    }
     const accountOwner = await users.select(['*'], [`id='${owner}'`]);
     const newBalance = parseFloat(balance) + parseFloat(creditAmount);
     const newTransaction = await transactions.create(
@@ -125,6 +132,13 @@ export default class TransactionController {
     }
 
     const { balance, owner } = accountToDebit[0];
+
+    if (req.decoded.id === owner) {
+      return res.status(401).json({
+        status: 401,
+        error: 'You are not allowed to carry out that action'
+      });
+    }
 
     if (debitAmount > balance) {
       return res.status(400).json({

--- a/server/controllers/UserController.js
+++ b/server/controllers/UserController.js
@@ -63,8 +63,8 @@ export default class UserController {
       }
       const { type, isAdmin } = findUser[0];
       if (type === 'staff' || isAdmin) {
-        return res.status(400).json({
-          status: 400,
+        return res.status(409).json({
+          status: 409,
           error: 'User is already a staff'
         });
       }

--- a/server/db/seeder.js
+++ b/server/db/seeder.js
@@ -81,6 +81,8 @@ const createTable = async () => {
   VALUES(8894354324, 3, 'olegunnar@manutd.com', 'current', 'draft', 43435.97);
   INSERT INTO accounts (accountNumber, owner, ownerEmail, type, status, balance)
   VALUES(4294354324, 2, 'thor@avengers.com', 'current', 'draft', 43435.97);
+  INSERT INTO accounts (accountNumber, owner, ownerEmail, type, status, balance)
+  VALUES(6754354123, 4, 'kyloren@vader.com', 'savings', 'active', 321324.7);
   INSERT INTO transactions (type, accountNumber, owner, cashier, amount, oldBalance, newBalance)
   VALUES('credit', 8897654324, 3, 4, 400500.0, 7264935.97, 7665435.97);
   INSERT INTO transactions (type, accountNumber, owner, cashier, amount, oldBalance, newBalance)

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -12,6 +12,7 @@ const API_PREFIX = '/api/v1';
 
 let authToken;
 let staffAuthToken;
+let upgradedUserToken;
 
 /**
  * @description Tests for transactions routes
@@ -34,7 +35,7 @@ describe('Transaction Route', () => {
 
   before(done => {
     const staff = {
-      email: 'kyloren@vader.com',
+      email: 'obiwan@therebellion.com',
       password: 'password123'
     };
     chai
@@ -43,6 +44,21 @@ describe('Transaction Route', () => {
       .send(staff)
       .end((_err, res) => {
         staffAuthToken = res.body.data[0].token;
+        done();
+      });
+  });
+
+  before(done => {
+    const staff = {
+      email: 'kyloren@vader.com',
+      password: 'password123'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/auth/signin`)
+      .send(staff)
+      .end((_err, res) => {
+        upgradedUserToken = res.body.data[0].token;
         done();
       });
   });
@@ -90,6 +106,28 @@ describe('Transaction Route', () => {
         expect(res.body)
           .to.have.property('error')
           .eql('You are not authorized to carry out that action');
+        expect(res.status).to.equal(401);
+        done();
+      });
+  });
+
+  it('Should not let a former client upgraded to a staff credit their account', done => {
+    const creditTransaction = {
+      creditAmount: 500900.05
+    };
+    const accountNumber = 6754354123;
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/transactions/${accountNumber}/credit`)
+      .set('Authorization', upgradedUserToken)
+      .send(creditTransaction)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(401);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('You are not allowed to carry out that action');
         expect(res.status).to.equal(401);
         done();
       });
@@ -249,6 +287,28 @@ describe('Transaction Route', () => {
         expect(res.body)
           .to.have.property('error')
           .eql('You are not authorized to carry out that action');
+        expect(res.status).to.equal(401);
+        done();
+      });
+  });
+
+  it('Should not let a former client upgraded to a staff debit their account', done => {
+    const debitTransaction = {
+      debitAmount: 500900.05
+    };
+    const accountNumber = 6754354123;
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/transactions/${accountNumber}/debit`)
+      .set('Authorization', upgradedUserToken)
+      .send(debitTransaction)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(401);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('You are not allowed to carry out that action');
         expect(res.status).to.equal(401);
         done();
       });

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -179,16 +179,16 @@ describe('User Routes', () => {
       .end((err, res) => {
         expect(res.body)
           .to.have.property('status')
-          .eql(400);
+          .eql(409);
         expect(res.body)
           .to.have.property('error')
           .eql('User is already a staff');
-        expect(res.status).to.equal(400);
+        expect(res.status).to.equal(409);
         done();
       });
   });
 
-  it('Should return an error if the user being upgraded does not exisit', done => {
+  it('Should return an error if the user being upgraded does not exist', done => {
     const userToUpdate = {
       userEmail: 'olesgunnars@manutd.com'
     };


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug where a user upgraded to staff can still perform transactions on accounts they own

#### Description of Task to be completed?
The staff should not be allowed to credit or debit their own accounts

#### How should this be manually tested?
After cloning the repo, `cd` into it and do the following:
```bash
# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run dev
```
Using Postman, you can visit the sign in route from #53 and sign in with the details from the test accounts and visit the route created in #73 to upgrade an existing user. Then, go to any of the transaction routes to perform a transaction on an account the user had before being upgraded to a staff

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#165627358](https://www.pivotaltracker.com/story/show/165627358)

#### Screenshots (if appropriate)
N/a