### PR TITLE
#165633232 Fix issue where a non-admin staff can delete a bank account

### DIFF
--- a/server/controllers/AccountController.js
+++ b/server/controllers/AccountController.js
@@ -178,11 +178,11 @@ export default class AccountController {
    * @param {Object} res The response object
    * @route DELETE /api/v1/accounts/:accountNumber
    * @returns {Object} status code, data and message properties
-   * @access private Staff only
+   * @access private Admin only
    */
   static async deleteAccount(req, res) {
     const { accountNumber } = req.params;
-    if (req.decoded.type === 'staff') {
+    if (req.decoded.type === 'staff' && req.decoded.isAdmin) {
       const accountToDelete = await accounts.select(
         ['*'],
         [`accountnumber=${parseInt(accountNumber, 10)}`]

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -12,6 +12,7 @@ const API_PREFIX = '/api/v1';
 
 let authToken;
 let staffAuthToken;
+let nonAdminStaffToken;
 const fakeAuthToken = 'jkkjkjkksdugvydy_.kdhdyuuuwll';
 /**
  * @description Test for accounts endpoint
@@ -43,6 +44,21 @@ describe('Account Route', () => {
       .send(staff)
       .end((err, res) => {
         staffAuthToken = res.body.data[0].token;
+        done();
+      });
+  });
+
+  before(done => {
+    const staff = {
+      email: 'kyloren@vader.com',
+      password: 'password123'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/auth/signin`)
+      .send(staff)
+      .end((err, res) => {
+        nonAdminStaffToken = res.body.data[0].token;
         done();
       });
   });
@@ -606,7 +622,7 @@ describe('Account Route', () => {
       });
   });
 
-  it('Should allow a staff user to do delete an account', done => {
+  it('Should allow an Admin staff user to do delete an account', done => {
     const accountNumber = 5563847290;
     chai
       .request(app)
@@ -620,6 +636,24 @@ describe('Account Route', () => {
           .to.have.property('message')
           .eql('Account deleted successfully');
         expect(res.status).to.equal(200);
+        done();
+      });
+  });
+
+  it('Should not allow an non-dmin staff user to do delete an account', done => {
+    const accountNumber = 5563847290;
+    chai
+      .request(app)
+      .delete(`${API_PREFIX}/accounts/${accountNumber}`)
+      .set('Authorization', nonAdminStaffToken)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(401);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('You are not authorized to delete an account');
+        expect(res.status).to.equal(401);
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where a non-admin cashier can delete a bank account

#### Description of Task to be completed?
A cashier should not be able to delete account even if they're not admins on the route: 
`DELETE /api/v1/accounts/<account-number>`

#### How should this be manually tested?
After cloning the repo, `cd` into it and do the following:
```bash
# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run dev
```
Using Postman, you can visit the sign in route from #53 and sign in as a cashier with the details from the test accounts visit the route stated above

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#165633232](https://www.pivotaltracker.com/story/show/165633232)

#### Screenshots (if appropriate)
N/a