### PR TITLE
#165637617 Admin can create a staff or admin user through the create user API endpoint

### DIFF
--- a/server/routes/UsersRoute.js
+++ b/server/routes/UsersRoute.js
@@ -6,16 +6,10 @@ import asyncErrorHandler from '../middleware/asyncErrorHandler';
 
 const router = Router();
 
-const { fetchAllAccountsByUser, adminAddStaff } = UserController;
+const { createStaff } = UserController;
 const { checkToken } = Authorization;
-const { validateFetchUsersAccounts, validateAddStaff } = UserValidation;
+const { validateCreateStaff } = UserValidation;
 
-router.get(
-  '/:userEmail/accounts',
-  checkToken,
-  validateFetchUsersAccounts,
-  asyncErrorHandler(fetchAllAccountsByUser)
-);
-router.patch('/', checkToken, validateAddStaff, asyncErrorHandler(adminAddStaff));
+router.post('/', checkToken, validateCreateStaff, asyncErrorHandler(createStaff));
 
 export default router;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,6 +3,7 @@ import authRoutes from './AuthRoute';
 import accountRoutes from './AccountRoute';
 import transactionRoutes from './TransactionRoute';
 import userRoutes from './UserRoute';
+import usersRoutes from './UsersRoute';
 
 const router = Router();
 
@@ -10,5 +11,6 @@ router.use('/auth', authRoutes);
 router.use('/accounts', accountRoutes);
 router.use('/transactions', transactionRoutes);
 router.use('/user', userRoutes);
+router.use('/users', usersRoutes);
 
 export default router;

--- a/server/validation/userValidation.js
+++ b/server/validation/userValidation.js
@@ -23,6 +23,15 @@ export default class UserValidation {
     return next();
   }
 
+  /**
+   * @description Function to check params when upgrading a user to a staff
+   * @param {Object} req The request object
+   * @param {Object} res The response object
+   * @param {Function} next Call back function
+   * @route PATCH /api/v1/users
+   * @returns {Object} status code and error message properties
+   * @access private
+   */
   static validateAddStaff(req, res, next) {
     const { userEmail } = req.body;
     if (Object.keys(req.body).length > 1) {
@@ -43,6 +52,78 @@ export default class UserValidation {
       return res.status(400).json({
         status: 400,
         error: 'Please provide a valid email address'
+      });
+    }
+
+    return next();
+  }
+
+  /**
+   * @description Function to check params when creating a staff
+   * @param {Object} req The request object
+   * @param {Object} res The response object
+   * @param {Function} next Call back function
+   * @route POST /api/v1/users
+   * @returns {Object} status code and error message properties
+   * @access private
+   */
+  static validateCreateStaff(req, res, next) {
+    const { firstName, lastName, email, admin } = req.body;
+    const containsAlphabets = /^[a-zA-Z ]*$/; // Gotten from Petar Ivanov on https://stackoverflow.com/questions/9289451/regular-expression-for-alphabets-with-spaces
+
+    if (isEmpty(firstName) && isEmpty(lastName) && isEmpty(email)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Please enter all required fields'
+      });
+    }
+
+    if (isEmpty(firstName)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'First name is required'
+      });
+    }
+
+    if (isEmpty(lastName)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Last name is required'
+      });
+    }
+
+    if (isEmpty(email)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Email is required'
+      });
+    }
+
+    if (!validEmail.test(email)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Please provide a valid email address'
+      });
+    }
+
+    if (!containsAlphabets.test(firstName)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'First name can only contain alphabets'
+      });
+    }
+
+    if (!containsAlphabets.test(lastName)) {
+      return res.status(400).json({
+        status: 400,
+        error: 'Last name can only contain alphabets'
+      });
+    }
+
+    if (!isEmpty(admin) && typeof admin !== 'boolean') {
+      return res.status(400).json({
+        status: 400,
+        error: 'Please specify true or false for admin'
       });
     }
 

--- a/swagger.json
+++ b/swagger.json
@@ -29,7 +29,7 @@
       "description": "API Endpoints for user actions in the app"
     }
   ],
-  "schemes": ["http"],
+  "schemes": ["http", "https"],
   "consumes": ["application/json", "application/x-www-form-urlencoded"],
   "produces": ["application/json"],
   "paths": {
@@ -1217,7 +1217,7 @@
     },
     "/api/v1/user/{userEmail}/accounts": {
       "get": {
-        "tags": ["Accounts"],
+        "tags": ["User"],
         "description": "Fetch all accounts a user owns",
         "summary": "Get all accounts a user owns",
         "consumes": ["application/json"],
@@ -1744,7 +1744,7 @@
         }
       }
     },
-    "/api/v1/user": {
+    "/api/v1/users": {
       "patch": {
         "tags": ["User"],
         "description": "Change a user type from client to staff",
@@ -1893,6 +1893,121 @@
                 "error": {
                   "type": "string",
                   "example": "User is already a staff"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["User"],
+        "description": "Create a Staff",
+        "summary": "Admin Staff Registration",
+        "consumes": ["application/json", "application/x-www-form-urlencoded"],
+        "parameters": [
+          {
+            "name": "newStaff",
+            "in": "body",
+            "required": true,
+            "description": "The request body containing all required, first name, last name, email and admin fields required for registration",
+            "example": {
+              "firstName": "Albus",
+              "lastName": "Dumbledore",
+              "email": "albus@hogwarts.com",
+              "admin": true
+            }
+          }
+        ],
+        "produces": ["application/json"],
+        "responses": {
+          "201": {
+            "description": "Successful Creation of a Staff",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "number",
+                  "example": 201
+                },
+                "data": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "token": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "number"
+                      },
+                      "firstName": {
+                        "type": "string"
+                      },
+                      "lastName": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      },
+                      "isadmin": {
+                        "type": "boolean"
+                      },
+                      "createdAt": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "example": [
+                    {
+                      "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NiwiZW1haWwiOiJzbmFwZUBob2d3YXJ0cy5jb20iLCJ0eXBlIjoiY2xpZW50IiwiZmlyc3ROYW1lIjoiU2V2ZXJ1cyIsImxhc3ROYW1lIjoiU25hcGUiLCJpc0FkbWluIjpmYWxzZSwiaWF0IjoxNTU1OTUwNjU1LCJleHAiOjE1NTU5NTQyNTV9.C04ZzO2jQy-87NTURx2yPg63dsI88pCxG4DqPH8sZLQ",
+                      "id": 7,
+                      "firstName": "Clark",
+                      "lastName": "Kent",
+                      "email": "notsuperman@test.com",
+                      "type": "staff",
+                      "isadmin": true,
+                      "createdat": "2019-04-22T16:30:55.066Z"
+                    }
+                  ]
+                },
+                "message": {
+                  "type": "string",
+                  "example": "Staff created successfully"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Required Field Missing",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "number",
+                  "example": 400
+                },
+                "error": {
+                  "type": "string",
+                  "example": "First name is required"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Duplicate Email",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "number",
+                  "example": 409
+                },
+                "error": {
+                  "type": "string",
+                  "example": "Staff already exists"
                 }
               }
             }

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -13,7 +13,7 @@ const API_PREFIX = '/api/v1/auth';
 /**
  * @description Test for sign up endpoint
  */
-describe('User Route', () => {
+describe('Auth Routes', () => {
   it('Should register a new user', done => {
     const newUser = {
       firstName: 'Darth',

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -293,4 +293,288 @@ describe('User Routes', () => {
         done();
       });
   });
+
+  it('Should create a new staff', done => {
+    const newUser = {
+      firstName: 'Clark',
+      lastName: 'Kent',
+      email: 'notsuperman@test.com'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/users`)
+      .set('Authorization', staffAuthToken)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(201);
+        expect(res.body)
+          .to.have.nested.property('data[0].type')
+          .eql('staff');
+        expect(res.status).to.equal(201);
+        done();
+      });
+  });
+
+  it('Should create a new staff', done => {
+    const newUser = {
+      admin: true,
+      firstName: 'Bruce',
+      lastName: 'Wayne',
+      email: 'realbatman@wayne.com'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/users`)
+      .set('Authorization', staffAuthToken)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(201);
+        expect(res.body)
+          .to.have.nested.property('data[0].type')
+          .eql('staff');
+        expect(res.status).to.equal(201);
+        done();
+      });
+  });
+
+  it('Should not create a new staff if the user is a not an admin', done => {
+    const newUser = {
+      admin: false,
+      firstName: 'Bruce',
+      lastName: 'Wayne',
+      email: 'realbatman@wayne.com'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/users`)
+      .set('Authorization', nonAdminStaffAuthToken)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(401);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('You are not allowed to carry out that action');
+        expect(res.status).to.equal(401);
+        done();
+      });
+  });
+
+  it('Should not create a new staff if the email already exists', done => {
+    const newUser = {
+      admin: false,
+      firstName: 'Bruce',
+      lastName: 'Wayne',
+      email: 'realbatman@wayne.com'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/users`)
+      .set('Authorization', staffAuthToken)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(409);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Staff already exists');
+        expect(res.status).to.equal(409);
+        done();
+      });
+  });
+
+  it('Should not create a new staff if the email field is empty', done => {
+    const newUser = {
+      admin: false,
+      firstName: 'Bruce',
+      lastName: 'Wayne',
+      email: ''
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/users`)
+      .set('Authorization', staffAuthToken)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Email is required');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
+  it('Should not create a new staff if the first name field is empty', done => {
+    const newUser = {
+      admin: false,
+      firstName: '',
+      lastName: 'Wayne',
+      email: 'something@email.com'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/users`)
+      .set('Authorization', staffAuthToken)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('First name is required');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
+  it('Should not create a new staff if the last name field is empty', done => {
+    const newUser = {
+      admin: false,
+      firstName: 'Bruce',
+      lastName: '',
+      email: 'something@email.com'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/users`)
+      .set('Authorization', staffAuthToken)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Last name is required');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
+  it('Should not create a new staff if all the required fields are empty', done => {
+    const newUser = {
+      firstName: '',
+      lastName: '',
+      email: ''
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/users`)
+      .set('Authorization', staffAuthToken)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Please enter all required fields');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
+  it('Should not create a new staff if the email field is empty', done => {
+    const newUser = {
+      admin: false,
+      firstName: 'Bruce',
+      lastName: 'Wayne',
+      email: 'notemail'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/users`)
+      .set('Authorization', staffAuthToken)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Please provide a valid email address');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
+  it('Should not create a new staff if the admin value is not a boolean', done => {
+    const newUser = {
+      admin: 'lol',
+      firstName: 'Bruce',
+      lastName: 'Wayne',
+      email: 'email@isreal.com'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/users`)
+      .set('Authorization', staffAuthToken)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Please specify true or false for admin');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
+  it('Should not create a new staff if the first name contains non-alphabets', done => {
+    const newUser = {
+      firstName: 'Cla77rk',
+      lastName: 'Kent',
+      email: 'notsuperman@test.com'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/users`)
+      .set('Authorization', staffAuthToken)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('First name can only contain alphabets');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
+
+  it('Should not create a new staff if the last name contains non-alphabets', done => {
+    const newUser = {
+      firstName: 'Clark',
+      lastName: '====00',
+      email: 'notsuperman@test.com'
+    };
+    chai
+      .request(app)
+      .post(`${API_PREFIX}/users`)
+      .set('Authorization', staffAuthToken)
+      .send(newUser)
+      .end((err, res) => {
+        expect(res.body)
+          .to.have.property('status')
+          .eql(400);
+        expect(res.body)
+          .to.have.property('error')
+          .eql('Last name can only contain alphabets');
+        expect(res.status).to.equal(400);
+        done();
+      });
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
Creates an endpoint for an admin to create other admins or cashier

#### Description of Task to be completed?
Have the following endpoint working: 
`POST /api/v1/users`

#### How should this be manually tested?
After cloning the repo, `cd` into it and do the following:
```bash
# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run dev
```
Using Postman, you can visit the sign in route from #53 and sign in with the details from the test accounts and visit the route stated above

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#165637617](https://www.pivotaltracker.com/story/show/165637617)

#### Screenshots (if appropriate)
N/a