### PR TITLE
#165654090 Fix issue where old balance and new balance are not returned on every transaction

### DIFF
--- a/server/controllers/TransactionController.js
+++ b/server/controllers/TransactionController.js
@@ -102,6 +102,8 @@ export default class TransactionController {
       amount: newTransaction[0].amount,
       cashier: newTransaction[0].cashier,
       transactionType: newTransaction[0].type,
+      oldBalance: newTransaction[0].oldbalance,
+      newBalance: newTransaction[0].newbalance,
       accountBalance: updatedAccount[0].balance
     };
     return res.status(200).json({
@@ -194,6 +196,8 @@ export default class TransactionController {
       amount: newTransaction[0].amount,
       cashier: newTransaction[0].cashier,
       transactionType: newTransaction[0].type,
+      oldBalance: newTransaction[0].oldbalance,
+      newBalance: newTransaction[0].newbalance,
       accountBalance: updatedAccount[0].balance
     };
     return res.status(200).json({

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -81,6 +81,8 @@ describe('Transaction Route', () => {
         expect(res.body)
           .to.have.nested.property('data[0].transactionType')
           .eql('credit');
+        expect(res.body).to.have.nested.property('data[0].oldBalance');
+        expect(res.body).to.have.nested.property('data[0].newBalance');
         expect(res.body)
           .to.have.property('message')
           .eql('Account credited successfully');
@@ -284,6 +286,8 @@ describe('Transaction Route', () => {
         expect(res.body)
           .to.have.nested.property('data[0].transactionType')
           .eql('debit');
+        expect(res.body).to.have.nested.property('data[0].oldBalance');
+        expect(res.body).to.have.nested.property('data[0].newBalance');
         expect(res.body)
           .to.have.property('message')
           .eql('Account debited successfully');


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where required old balance and new balance data for new transactions are not returned

#### Description of Task to be completed?
Every transaction must have an `oldbalance` and `newbalance` property and should be sent in the response body whenever a new transaction is carried out

#### How should this be manually tested?
After cloning the repo, `cd` into it and do the following:
```bash
# install dependencies
$ npm install

# run unit tests
$ npm test

# start the development server
$ npm run dev
```
Using Postman, you can visit the sign in route from #53 and sign in with the details from the test accounts and visit the routes created in #55 to consummate a new transaction on an existing account

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#165654090](https://www.pivotaltracker.com/story/show/165654090)

#### Screenshots (if appropriate)
