### PR TITLE
#165903564 Staff can delete a client's bank account

### DIFF
--- a/www/admin/accountinfo.html
+++ b/www/admin/accountinfo.html
@@ -65,10 +65,16 @@
       </div>
       <div class="nav-area"></div>
       <div class="shortcut-btns">
-        <a href="#" onclick="handleStatusChange()" id="accnt-status-btn">Activate Account</a>
-        <a href="#" onclick="showDebitForm()" id="accnt-status-btn">Debit Account</a>
-        <a href="#" onclick="showCreditForm()" id="accnt-status-btn">Credit Account</a>
-        <a href="#" onclick="handleAccountDelete()" id="accnt-status-btn" class="accnt-delete-btn"
+        <a href="javascript:;" onclick="handleStatusChange()" id="accnt-status-btn"
+          >Activate Account</a
+        >
+        <a href="javascript:;" onclick="showDebitForm()" id="accnt-status-btn">Debit Account</a>
+        <a href="javascript:;" onclick="showCreditForm()" id="accnt-status-btn">Credit Account</a>
+        <a
+          href="javascript:;"
+          onclick="showDeleteModal()"
+          id="accnt-status-btn"
+          class="accnt-delete-btn"
           >Delete Account</a
         >
       </div>
@@ -155,8 +161,10 @@
             </form>
             <div id="confirm-delete">
               <p class="confirm-delete">Are you sure you want to delete this account?</p>
-              <button class="confirm-delete-accnt-btn">Delete</button>
-              <button class="delete-accnt-btn">Cancel</button>
+              <button class="confirm-delete-accnt-btn" onclick="handleAccountDelete();">
+                Delete
+              </button>
+              <button class="delete-accnt-btn" onclick="hideDeleteDisplay()">Cancel</button>
             </div>
           </div>
         </div>

--- a/www/js/fetchSingleAccountHistory.js
+++ b/www/js/fetchSingleAccountHistory.js
@@ -140,6 +140,14 @@ const showCreditForm = () => {
   modal.style.display = 'block';
 };
 
+const showDeleteModal = () => {
+  para.innerHTML = '';
+  debitForm.style.display = 'none';
+  creditForm.style.display = 'none';
+  confirmDeleteMsg.style.display = 'block';
+  modal.style.display = 'block';
+};
+
 const handleAccountDebit = () => {
   const debitAmount = document.getElementById('debit-amount').value;
   const debitBtn = document.getElementById('debit-btn');
@@ -256,6 +264,39 @@ const handleStatusChange = () => {
       log(err.message);
       handleError('An error occurred. Please try again');
     });
+};
+
+const handleAccountDelete = () => {
+  const accountNumber = localStorage.getItem('banka-account-number-view');
+  const token = localStorage.getItem('banka-app-token');
+  const headers = new Headers();
+  headers.append('Content-Type', 'application/json');
+  headers.append('Authorization', token);
+  confirmDeleteMsg.innerHTML = 'Loading...';
+  fetch(`${API_PREFIX}/accounts/${accountNumber}`, {
+    method: 'DELETE',
+    headers
+  })
+    .then(res => res.json())
+    .then(response => {
+      if (response.status === 200) {
+        confirmDeleteMsg.innerHTML = `${response.message}`;
+        setTimeout(() => {
+          window.location = 'dashboard.html';
+        }, 2000);
+      } else {
+        confirmDeleteMsg.innerHTML = `${response.error}`;
+      }
+    })
+    .catch(err => {
+      const { log } = console;
+      log(err.message);
+      handleError('An error occurred');
+    });
+};
+
+const hideDeleteDisplay = () => {
+  modal.style.display = 'none';
 };
 
 span.onclick = () => {


### PR DESCRIPTION
#### What does this PR do?
Adds functionality to frontend template for staff to delete a client's bank account

#### Description of Task to be completed?
An admin should be able to delete an existing bank account under a user

#### How should this be manually tested?
VIsit the hosted pages [here](https://tolulope-od.github.io/banka) and login as an admin user, navigate to the `accounts` page and click the `details` button to view available actions for the account as well as transaction history for the account. On the account details page, click the `delete account` button

#### Any background context you want to provide?
N/a

#### What are the relevant pivotal tracker stories?
[#165903564](https://www.pivotaltracker.com/story/show/165903564)

#### Screenshots (if appropriate)
![Screenshot 2019-05-09 at 9 30 18 AM](https://user-images.githubusercontent.com/42325628/57439051-1b69c980-723d-11e9-9780-68778eb0adf8.png)

